### PR TITLE
Fix the country filter label when clicking on a country on the map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to this project will be documented in this file.
 - Fix broken favicons when domain includes a slash
 - Fix bug when using multiple [wildcard goal filters](https://github.com/plausible/analytics/pull/3015)
 - Fix a bug where realtime would fail with imported data
+- Fix a bug where the country name was not shown when [filtering through the map](https://github.com/plausible/analytics/issues/3086)
 
 ### Changed
 - Treat page filter as entry page filter for `bounce_rate`

--- a/assets/js/dashboard/stats/locations/map.js
+++ b/assets/js/dashboard/stats/locations/map.js
@@ -27,7 +27,7 @@ class Countries extends React.Component {
   componentDidUpdate(prevProps) {
     if (this.props.query !== prevProps.query) {
       // eslint-disable-next-line react/no-did-update-set-state
-      this.setState({loading: true, countries: null})
+      this.setState({ loading: true, countries: null })
       this.fetchCountries().then(this.drawMap)
     }
   }
@@ -48,19 +48,19 @@ class Countries extends React.Component {
   getDataset() {
     const dataset = {};
 
-    var onlyValues = this.state.countries.map(function(obj){ return obj.visitors });
+    var onlyValues = this.state.countries.map(function (obj) { return obj.visitors });
     var maxValue = Math.max.apply(null, onlyValues);
 
     // eslint-disable-next-line no-undef
     const paletteScale = d3.scale.linear()
-      .domain([0,maxValue])
+      .domain([0, maxValue])
       .range([
         this.state.darkTheme ? "#2e3954" : "#f3ebff",
         this.state.darkTheme ? "#6366f1" : "#a779e9"
       ])
 
-    this.state.countries.forEach(function(item){
-      dataset[item.alpha_3] = {numberOfThings: item.visitors, fillColor: paletteScale(item.visitors)};
+    this.state.countries.forEach(function (item) {
+      dataset[item.alpha_3] = { numberOfThings: item.visitors, fillColor: paletteScale(item.visitors) };
     });
 
     return dataset
@@ -68,13 +68,13 @@ class Countries extends React.Component {
 
   updateCountries() {
     this.fetchCountries().then(() => {
-      this.map.updateChoropleth(this.getDataset(), {reset: true})
+      this.map.updateChoropleth(this.getDataset(), { reset: true })
     })
   }
 
   fetchCountries() {
-    return api.get(`/api/stats/${encodeURIComponent(this.props.site.domain)}/countries`, this.props.query, {limit: 300})
-      .then((res) => this.setState({loading: false, countries: res}))
+    return api.get(`/api/stats/${encodeURIComponent(this.props.site.domain)}/countries`, this.props.query, { limit: 300 })
+      .then((res) => this.setState({ loading: false, countries: res }))
   }
 
   resizeMap() {
@@ -121,7 +121,7 @@ class Countries extends React.Component {
               this.props.query,
               {
                 country: country.code,
-                country_name: country.name
+                country_labels: country.name
               }
             )
           }
@@ -145,9 +145,9 @@ class Countries extends React.Component {
     if (this.state.countries) {
       return (
         <>
-          <div className="mx-auto mt-4" style={{width: '100%', maxWidth: '475px', height: '335px'}} id="map-container"></div>
+          <div className="mx-auto mt-4" style={{ width: '100%', maxWidth: '475px', height: '335px' }} id="map-container"></div>
           <MoreLink site={this.props.site} list={this.state.countries} endpoint="countries" />
-          { this.geolocationDbNotice() }
+          {this.geolocationDbNotice()}
         </>
       )
     }
@@ -158,9 +158,9 @@ class Countries extends React.Component {
   render() {
     return (
       <LazyLoader onVisible={this.onVisible}>
-        { this.state.loading && <div className="mx-auto my-32 loading"><div></div></div> }
+        {this.state.loading && <div className="mx-auto my-32 loading"><div></div></div>}
         <FadeIn show={!this.state.loading}>
-          { this.renderBody() }
+          {this.renderBody()}
         </FadeIn>
       </LazyLoader>
     )


### PR DESCRIPTION
### Changes

The filter label takes the value from the `country_labels` field and not `country_name`.
By changing the property to `country_labels`, the correct name shows up in the filter

### Tests
- [X] This PR does not require tests

### Changelog
- [X] Entry has been added to changelog

### Documentation
- [X] This change does not need a documentation update

### Dark mode
- [X] The UI has been tested both in dark and light mode
